### PR TITLE
Added additional guards to enable builds without security feature enabled.

### DIFF
--- a/dds/src/dcps/dcps_reader.c
+++ b/dds/src/dcps/dcps_reader.c
@@ -28,7 +28,9 @@
 #include "pool.h"
 #include "str.h"
 #include "error.h"
+#ifdef DDS_SECURITY
 #include "dds/dds_security.h"
+#endif //DDS_SECURITY
 #include "dds/dds_dcps.h"
 #include "dds_data.h"
 #include "domain.h"

--- a/dds/src/dcps/dcps_writer.c
+++ b/dds/src/dcps/dcps_writer.c
@@ -27,7 +27,9 @@
 #include "prof.h"
 #include "error.h"
 #include "str.h"
+#ifdef DDS_SECURITY
 #include "dds/dds_security.h"
+#endif //DDS_SECURITY
 #include "dds/dds_dcps.h"
 #include "dds_data.h"
 #include "domain.h"

--- a/dds/src/disc/disc_ctt.c
+++ b/dds/src/disc/disc_ctt.c
@@ -31,8 +31,8 @@
 #include "dds.h"
 #include "dcps.h"
 #include "dds/dds_debug.h"
-#include "dds/dds_security.h"
 #ifdef DDS_SECURITY
+#include "dds/dds_security.h"
 #include "security.h"
 #ifdef DDS_NATIVE_SECURITY
 #include "sec_auth.h"

--- a/dds/src/disc/disc_main.c
+++ b/dds/src/disc/disc_main.c
@@ -40,8 +40,8 @@
 #include "guard.h"
 #include "dcps.h"
 #include "dds/dds_debug.h"
-#include "dds/dds_security.h"
 #ifdef DDS_SECURITY
+#include "dds/dds_security.h"
 #include "security.h"
 #ifdef DDS_NATIVE_SECURITY
 #include "sec_auth.h"

--- a/dds/src/disc/disc_psmp.c
+++ b/dds/src/disc/disc_psmp.c
@@ -30,8 +30,8 @@
 #include "dds.h"
 #include "dcps.h"
 #include "dds/dds_debug.h"
-#include "dds/dds_security.h"
 #ifdef DDS_SECURITY
+#include "dds/dds_security.h"
 #include "security.h"
 #ifdef DDS_NATIVE_SECURITY
 #ifdef DDS_QEO_TYPES

--- a/dds/src/disc/disc_spdp.c
+++ b/dds/src/disc/disc_spdp.c
@@ -25,8 +25,8 @@
 #include "error.h"
 #include "thread.h"
 #include "dds.h"
-#include "dds/dds_security.h"
 #ifdef DDS_SECURITY
+#include "dds/dds_security.h"
 #include "security.h"
 #ifdef DDS_NATIVE_SECURITY
 #include "sec_auth.h"
@@ -56,6 +56,7 @@
 #include "disc_msg.h"
 #include "disc_sedp.h"
 #include "disc_spdp.h"
+#include "dds/dds_plugin.h"
 
 #ifdef SIMPLE_DISCOVERY
 
@@ -705,8 +706,10 @@ void spdp_end_participant (Participant_t *pp, int ignore)
 	if (ignore) {
 
 		/* Set ignored status. */
+#ifdef DDS_NATIVE_SECURITY
 		locator_list_delete_list (&pp->p_uc_locs);
 		pp->p_uc_dreply = NULL;
+#endif
 		pp->p_flags &= ~(EF_NOT_IGNORED | EF_SHUTDOWN);
 		return;
 	}

--- a/dds/src/xtypes/xtopic.c
+++ b/dds/src/xtypes/xtopic.c
@@ -12,7 +12,9 @@
  * See LICENSE file for more details.
  */
 
+#ifdef DDS_SECURITY
 #include "dds/dds_security.h"
+#endif //DDS_SECURITY
 #include "dds/dds_xtypes.h"
 #include "dds/dds_dwriter.h"
 #include "dds/dds_dreader.h"


### PR DESCRIPTION
This pull request fixes some compilation problems that may arise if DDS_SECURITY flag is disabled and you are building the library without OpenSSL support.
